### PR TITLE
Better chat nick notifications

### DIFF
--- a/MainWindow.monkey2
+++ b/MainWindow.monkey2
@@ -1020,21 +1020,41 @@ Class MainWindowInstance Extends Window
 	End
 	
 	Method OnChatClicked()
+		
 		If _consolesTabView.CurrentView<>_ircView Then Return
 		
 		_consolesTabView.SetTabIcon( _ircView, Null )
+		
 		_ircNotifyIcon=0
+		
+		HideHint()
+		
 	End
 	
 	Method OnChatMessage( message:IRCMessage, container:IRCMessageContainer, server:IRCServer )
+		
 		If message.type<>"PRIVMSG" Or _consolesTabView.CurrentView=_ircView Then Return
 		
 		'Show notice icon
 		If message.text.Contains(server.nickname) Then
-			If _ircNotifyIcon<=1 Then _ircNotifyIcon=2
-	
+			
+			If _ircNotifyIcon<=1 Then
+				
+				_ircNotifyIcon=2
+				
+				Local mentionStr:String
+				mentionStr=server.nickname+" was mentioned by "
+				mentionStr+=message.fromUser+" in "
+				mentionStr+=container.name
+				
+				ShowHint( mentionStr, New Vec2i( 0, -GetStyle( "Hint" ).Font.Height*4 ), _consolesTabView, 20000 )
+				
+			Endif
+			
 		Else
+			
 			If _ircNotifyIcon<=0 Then _ircNotifyIcon=1
+			
 		Endif
 		
 	End


### PR DESCRIPTION
_A 'Hint' is now displayed near the console when your name is mentioned in the chat_

I feel like this could be done more elegantly...
It doesn't get in the way or anything and the code is fine, but it does not align 100% correctly.
Since there's no way to tell how tall the console TabBar (actual tab part) actually is, it uses its own text height to adjust itself above the tabs.

Anyways, it stays on screen for 20 seconds and goes away when you do one of the follow things:
1. Switch to the Chat tab
2. Hover any other icon that displays a 'Hint'
(3. And of course leave it alone for 20 seconds)
So it doesn't get in the way and I don't feel like its intrusive.
It's only when someone actually mentions your IRC nickname.

Here's how it looks: https://puu.sh/wTjuq/9edd935e08.png