### PR TITLE
MacOS Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.buildv*
 *.products/
 *.app
+*.DS_*

--- a/product/BuildProduct.monkey2
+++ b/product/BuildProduct.monkey2
@@ -384,6 +384,8 @@ Class MacosProduct Extends DesktopProduct
 		plist+="<!DOCTYPE plist PUBLIC ~q-//Apple Computer//DTD PLIST 1.0//EN~q ~qhttp://www.apple.com/DTDs/PropertyList-1.0.dtd~q>~n"
 		plist+="<plist version=~q1.0~q>~n"
 		plist+="<dict>~n"
+		plist+="~t<key>CFBundleName</key>~n"
+		plist+="~t<string>"+AppName+"</string>~n"
 		plist+="~t<key>CFBundleExecutable</key>~n"
 		plist+="~t<string>"+AppName+"</string>~n"
 		plist+="~t<key>CFBundleIconFile</key>~n"


### PR DESCRIPTION
- Added "CFBundleName" to info.plist generation. Without this it's impossible to associate Ted2Go to .monkey2 files system wide in MacOS.

- Add ".DS_*" to .gitignore to prevent.DS_Store files from being added to GitHub. These files are hidden and only store metadata in MacOS.