### PR TITLE
Added some monkeydocs templates

### DIFF
--- a/assets/liveTemplates.json
+++ b/assets/liveTemplates.json
@@ -1,6 +1,9 @@
 {
 	".monkey2":{
 		"do":"Repeat\n\t${Cursor}\nForever",
+		"doca":"#Rem monkeydoc ${cursor}\n\t...\n\t@param val descr\n\t\n    @example\n    \t...\n    @end\n#End\n",
+		"docd":"#Rem monkeydoc ${Cursor}\n\tdetails [[class name]]\n#End\n",
+		"docs":"#Rem monkeydoc ${Cursor}\n#End",
 		"dou":"Repeat\n\t\nUntil _${Cursor}",
 		"each":"For Local ${Cursor}:=Eachin _\n\t\nNext",
 		"fib":"New Fiber( Lambda()\n\t${Cursor}\nEnd )",


### PR DESCRIPTION
# Proposal
Add some monkeydoc templates. 

### Why?
- (probably or will be?) used fairly frequently and commonly
- much faster to write
- less to remember
- new users will be able to start using monkeys built in documenting system with less friction

### Convention
- `doca`: a template for large commonly used features
- `docd`: a template for document with extra details
- `docs`: a template for a one-liner


### Extra
Feel free to decline, merge, or change how you see fit. I imagine the convention may be up to debate, for example, people may want to write `docs` more commonly than `doca` so maybe shorten `docs` to `doc`? Also maybe `#` is more appropriate in front of them? 

_Note:_ For some reason, GitHub changes the EOF. I can fix this locally if you like! 